### PR TITLE
endpoints for facilitymineralsID

### DIFF
--- a/Exomine2JSWSAFAPI/Program.cs
+++ b/Exomine2JSWSAFAPI/Program.cs
@@ -451,6 +451,56 @@ app.MapGet("/facilityMinerals", () =>
 
     return Results.Ok(facilityMineralDTOs);
 });
+// get single facility mineral by ID with expanded mineral
+
+app.MapGet("/facilityMinerals/{id}", (int id) =>
+{
+    FacilityMineral facilityMineral = facilityMinerals.FirstOrDefault(fm => fm.Id == id);
+    if (facilityMineral == null)
+    {
+        return Results.NotFound();
+    }
+    FacilityMineralDTO facilityMineralData = new FacilityMineralDTO
+    {
+        Id = facilityMineral.Id,
+        Quantity = facilityMineral.Quantity,
+        FacilityId = facilityMineral.FacilityId,
+        MineralId = facilityMineral.MineralId,
+        Facility = facilities.FirstOrDefault(f => f.Id == facilityMineral.FacilityId),
+        Mineral = minerals.FirstOrDefault(m => m.Id == facilityMineral.MineralId)
+    };
+    return Results.Ok(facilityMineralData);
+});
+
+// updating facility mineral (decreasing after purchase)
+app.MapPut("/facilityMinerals/{id}", (int id, int amountPurchased) =>
+{
+    FacilityMineral facilityMineral = facilityMinerals.FirstOrDefault(fm => fm.Id == id);
+    if (facilityMineral == null)
+    {
+        return Results.NotFound();
+    }
+    if (amountPurchased > facilityMineral.Quantity) // checks amount trying to purchase greater than total amount
+    {
+        return Results.BadRequest();
+    }
+    facilityMineral.Quantity = facilityMineral.Quantity - amountPurchased;
+
+    FacilityMineralDTO updatedDTO = new FacilityMineralDTO
+    {
+        Id = facilityMineral.Id,
+        Quantity = facilityMineral.Quantity,
+        FacilityId = facilityMineral.FacilityId,
+        MineralId = facilityMineral.MineralId,
+        Facility = facilities.FirstOrDefault(f => f.Id == facilityMineral.FacilityId),
+        Mineral = minerals.FirstOrDefault(m => m.Id == facilityMineral.MineralId)
+    };
+    return Results.Ok(updatedDTO);
+
+
+
+});
+
 
 
 


### PR DESCRIPTION
### Summary
GET method endpoint /facilityMinerals/{id}
- gets single facility mineral by ID
- expands it to include facility and mineral data
PUT method enpoint /facilityMinerals/{id}
- updated quantity of facility mineral after purchase (decreases the total quantity)
- prevents buying more than available

###Files changes: 
program.cs

###How to test
Run app and open swagger
run the GET/facilityMineral/{id} endpoint
should see: Id, facilityID, MineralID, quantity, expanded facility and mineral 
--
Find the PUT /facilityMinerals/{id} endpoint in Swagger.
Enter:
a valid FacilityMineral ID (like 1)
and an amountPurchased (like 5).
Click Execute.
You should see:
the quantity decreased by the amount you purchased.
the updated Facility and Mineral expanded information.
Try purchasing more than available 
It should return 400 Bad Request
