### PR TITLE
Added Endpoint for production sim, and new prop on fm

### DIFF
--- a/Exomine2JSWSAFAPI/Models/DTOs/FacilityMineralDTO.cs
+++ b/Exomine2JSWSAFAPI/Models/DTOs/FacilityMineralDTO.cs
@@ -6,6 +6,7 @@ public class FacilityMineralDTO
     public int Quantity { get; set; }
     public int FacilityId { get; set; }
     public int MineralId { get; set; }
+    public int ProductionRate { get; set; }
     public Facility Facility { get; set; }
     public Mineral Mineral { get; set; }
 

--- a/Exomine2JSWSAFAPI/Models/FacilityMineral.cs
+++ b/Exomine2JSWSAFAPI/Models/FacilityMineral.cs
@@ -6,4 +6,6 @@ public class FacilityMineral
     public int FacilityId {get; set;}
     public int MineralId {get; set;}
     public int Quantity {get; set;}
+
+    public int ProductionRate { get; set; }
 }

--- a/Exomine2JSWSAFAPI/Program.cs
+++ b/Exomine2JSWSAFAPI/Program.cs
@@ -231,70 +231,81 @@ List<FacilityMineral> facilityMinerals = new List<FacilityMineral>
         Id = 1,
         FacilityId = 1,
         MineralId = 1,
-        Quantity = 98
+        Quantity = 98,
+        ProductionRate = 3
     },
     new FacilityMineral
     {
         Id = 2,
         FacilityId = 2,
         MineralId = 2,
-        Quantity = 107
+        Quantity = 107,
+        ProductionRate = 3
+
     },
     new FacilityMineral
     {
         Id = 3,
         FacilityId = 3,
         MineralId = 3,
-        Quantity = 148
+        Quantity = 148,
+        ProductionRate = 3
     },
     new FacilityMineral
     {
         Id = 4,
         FacilityId = 4,
         MineralId = 4,
-        Quantity = 62
+        Quantity = 62,
+        ProductionRate = 3
     },
     new FacilityMineral
     {
         Id = 5,
         FacilityId = 5,
         MineralId = 5,
-        Quantity = 593
+        Quantity = 593,
+        ProductionRate = 3
     },
     new FacilityMineral
     {
         Id = 6,
         FacilityId = 4,
         MineralId = 1,
-        Quantity = 99
+        Quantity = 99,
+        ProductionRate = 3
     },
     new FacilityMineral
     {
         Id = 7,
         FacilityId = 3,
         MineralId = 2,
-        Quantity = 102
+        Quantity = 102,
+        ProductionRate = 3
     },
     new FacilityMineral
     {
         Id = 8,
         FacilityId = 5,
         MineralId = 3,
-        Quantity = 159
+        Quantity = 159,
+        ProductionRate = 3
     },
     new FacilityMineral
     {
         Id = 9,
         FacilityId = 2,
         MineralId = 4,
-        Quantity = 62
+        Quantity = 62,
+        ProductionRate = 3
     },
     new FacilityMineral
     {
         Id = 10,
         FacilityId = 1,
         MineralId = 5,
-        Quantity = 591
+        Quantity = 591,
+        ProductionRate = 3
     },
 };
 List<Facility> facilities = new List<Facility>
@@ -560,6 +571,30 @@ app.MapPut("/colonyMinerals/{id}",(int id, ColonyMineral colonyMineral)=>
         Colony = colonies.FirstOrDefault(c => c.Id == colonyMineral.ColonyId),
         Mineral = minerals.FirstOrDefault(m => m.Id == colonyMineral.MineralId)
     });
+});
+
+
+// Simulate Production
+app.MapPost("/simulateProduction", () => {
+    var updatedItems = new List<FacilityMineralDTO>();
+
+    foreach (var fm in facilityMinerals)
+    {
+        fm.Quantity += fm.ProductionRate;
+
+        updatedItems.Add(new FacilityMineralDTO
+        {
+            Id = fm.Id,
+            FacilityId = fm.FacilityId,
+            MineralId = fm.MineralId,
+            Quantity = fm.Quantity,
+            ProductionRate = fm.ProductionRate,
+            Facility = facilities.FirstOrDefault(f => f.Id == fm.FacilityId),
+            Mineral = minerals.FirstOrDefault(m => m.Id == fm.MineralId)
+        });
+    }
+
+    return Results.Ok(updatedItems);
 });
 
 app.Run();


### PR DESCRIPTION
## 🚀 Add `POST /simulateProduction` Endpoint for Mineral Growth

### Summary

This pull request introduces a new API endpoint:

```http
POST /simulateProduction
```

When triggered, this endpoint simulates a time tick in the system — incrementing the `Quantity` of each `FacilityMineral` by its respective `ProductionRate`.

---

### 🧱 Implementation Details

- A new field `ProductionRate` has been added to the `FacilityMineral` model.
- The endpoint loops through all `facilityMinerals` and increments their quantities.
- The updated `FacilityMineral` records are returned as a list of DTOs.
- DTO mapping uses `.FirstOrDefault()` to safely handle edge cases where referenced facility or mineral data might be missing.

---

### ✅ Why `.FirstOrDefault()`?

Using `.FirstOrDefault()` ensures this endpoint is more resilient — especially in future scenarios where `Facility` or `Mineral` relationships might be removed, incomplete, or temporarily inconsistent. This helps prevent unhandled runtime exceptions and keeps the API stable under edge conditions.

---

### 🔬 Example Response

```json
[
  {
    "id": 1,
    "quantity": 122,
    "facilityId": 1,
    "mineralId": 1,
    "productionRate": 3,
    "facility": {
      "id": 1,
      "name": "Celestial Excavation Hub",
      "isActive": true
    },
    "mineral": {
      "id": 1,
      "name": "Xenorite"
    }
  },
  ...
]
```

---

### 🧪 Next Steps

- Hook up a **“Simulate Production”** button in the React frontend to POST to this endpoint.
- Optionally trigger a re-fetch of `/facilityMinerals` afterward to reflect updated quantities in the UI.

---